### PR TITLE
nopo11y dashboard uid and alert changes

### DIFF
--- a/charts/nopo11y/Chart.yaml
+++ b/charts/nopo11y/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.0
+version: 1.0.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/nopo11y/Chart.yaml
+++ b/charts/nopo11y/Chart.yaml
@@ -21,4 +21,4 @@ version: 1.0.0
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "1.0.0"
+appVersion: "1.0.1"

--- a/charts/nopo11y/templates/_helpers.tpl
+++ b/charts/nopo11y/templates/_helpers.tpl
@@ -1,0 +1,3 @@
+{{- define "dashboard-uid" -}}
+{{- printf "%s-%s" .Release.Name .Release.Namespace |trunc 40 -}}
+{{- end -}}

--- a/charts/nopo11y/templates/_helpers.tpl
+++ b/charts/nopo11y/templates/_helpers.tpl
@@ -1,3 +1,3 @@
 {{- define "dashboard-uid" -}}
-{{- printf "%s-%s" .Release.Name .Release.Namespace |trunc 40 -}}
+{{- printf "%s-%s" .Release.Name .Release.Namespace | trunc 40 -}}
 {{- end -}}

--- a/charts/nopo11y/templates/defaultAlerts.yaml
+++ b/charts/nopo11y/templates/defaultAlerts.yaml
@@ -10,66 +10,6 @@ spec:
   groups:
   - name: {{ .Values.appLabel }}-default-alert-rules
     rules:
-    - alert: {{ .Values.appLabel }}HighCpuUtilization
-      {{- if .Values.includeReleaseNameInMetricsLabels }}
-      expr: 100 * max(rate(container_cpu_usage_seconds_total{pod=~"{{ .Release.Name }}-{{ .Values.deploymentName }}.*"}[5m])/ on (container, pod) kube_pod_container_resource_requests{resource="cpu"}) by (pod) > 80
-      {{- else }}
-      expr: 100 * max(rate(container_cpu_usage_seconds_total{pod=~"{{ .Values.deploymentName }}.*"}[5m])/ on (container, pod) kube_pod_container_resource_requests{resource="cpu"}) by (pod) > 80
-      {{- end }}
-      for: 10m
-      annotations:
-        description: CPU utilization of pod {{ "{{" }} $labels.pod {{ "}}" }} is above 80% from last 5 minutes .
-        summary: CPU Utilization went over 80% for pod {{ "{{" }} $labels.pod {{ "}}" }}.
-        {{- if .Values.grafanaURL }}
-        dashboard: {{ .Values.grafanaURL }}/d/{{- if .Values.includeReleaseNameInMetricsLabels }}{{ .Release.Name }}-{{ .Values.appLabel }}{{- else }}{{ .Values.appLabel }}{{- end }}-overview
-        {{- end }}
-      labels:
-            severity: warning
-    - alert: {{ .Values.appLabel }}HighCpuUtilization
-      {{- if .Values.includeReleaseNameInMetricsLabels }}
-      expr: 100 * max(rate(container_cpu_usage_seconds_total{pod=~"{{ .Release.Name }}-{{ .Values.deploymentName }}.*"}[5m])/ on (container, pod) kube_pod_container_resource_requests{resource="cpu"}) by (pod) > 90
-      {{- else }}
-      expr: 100 * max(rate(container_cpu_usage_seconds_total{pod=~"{{ .Values.deploymentName }}.*"}[5m])/ on (container, pod) kube_pod_container_resource_requests{resource="cpu"}) by (pod) > 90
-      {{- end }}
-      for: 10m
-      annotations:
-        description: CPU utilization of pod {{ "{{" }} $labels.pod {{ "}}" }} is above 90% from last 5 minutes.
-        summary: CPU Utilization went over 90% for pod {{ "{{" }} $labels.pod {{ "}}" }}.
-        {{- if .Values.grafanaURL }}
-        dashboard: {{ .Values.grafanaURL }}/d/{{- if .Values.includeReleaseNameInMetricsLabels }}{{ .Release.Name }}-{{ .Values.appLabel }}{{- else }}{{ .Values.appLabel }}{{- end }}-overview
-        {{- end }}
-      labels:
-            severity: critical
-    - alert: {{ .Values.appLabel }}HighMemoryUtilization
-      {{- if .Values.includeReleaseNameInMetricsLabels }}
-      expr: 100 * max( container_memory_working_set_bytes{pod=~"{{ .Release.Name }}-{{ .Values.deploymentName }}.*"} / on (container, pod) kube_pod_container_resource_limits{resource="memory"}) by (pod) > 80
-      {{- else }}
-      expr: 100 * max( container_memory_working_set_bytes{pod=~"{{ .Values.deploymentName }}.*"} / on (container, pod) kube_pod_container_resource_limits{resource="memory"}) by (pod) > 80
-      {{- end }}
-      for: 10m
-      annotations:
-        description: Memory utilization of pod {{ "{{" }} $labels.pod {{ "}}" }} is above 80% from last 5 minutes.
-        summary: Memory Utilization went over 80% for pod {{ "{{" }} $labels.pod {{ "}}" }}.
-        {{- if .Values.grafanaURL }}
-        dashboard: {{ .Values.grafanaURL }}/d/{{- if .Values.includeReleaseNameInMetricsLabels }}{{ .Release.Name }}-{{ .Values.appLabel }}{{- else }}{{ .Values.appLabel }}{{- end }}-overview
-        {{- end }}
-      labels:
-            severity: warning
-    - alert: {{ .Values.appLabel }}HighMemoryUtilization
-      {{- if .Values.includeReleaseNameInMetricsLabels }}
-      expr: 100 * max( container_memory_working_set_bytes{pod=~"{{ .Release.Name }}-{{ .Values.deploymentName }}.*"} / on (container, pod) kube_pod_container_resource_limits{resource="memory"}) by (pod) > 90
-      {{- else }}
-      expr: 100 * max( container_memory_working_set_bytes{pod=~"{{ .Values.deploymentName }}.*"} / on (container, pod) kube_pod_container_resource_limits{resource="memory"}) by (pod) > 90
-      {{- end }}
-      for: 10m
-      annotations:
-        description: Memory utilization of pod {{ "{{" }} $labels.pod {{ "}}" }} is above 90% from last 5 minutes.
-        summary: Memory Utilization went over 90% for pod {{ "{{" }} $labels.pod {{ "}}" }}.
-        {{- if .Values.grafanaURL }}
-        dashboard: {{ .Values.grafanaURL }}/d/{{- if .Values.includeReleaseNameInMetricsLabels }}{{ .Release.Name }}-{{ .Values.appLabel }}{{- else }}{{ .Values.appLabel }}{{- end }}-overview
-        {{- end }}
-      labels:
-            severity: critical
     {{- if .Values.istioMetrics.enabled }}
     - alert: {{ .Values.appLabel }}High5xxErrorRate
       {{- if .Values.includeReleaseNameInMetricsLabels }}
@@ -81,7 +21,7 @@ spec:
         description: {{- if .Values.includeReleaseNameInMetricsLabels }} {{ .Release.Name }}-{{ .Values.appLabel }}{{- else }} {{ .Values.appLabel }}{{- end }} service is experiencing high 5xx errors rate from last 5 minutes.
         summary: {{- if .Values.includeReleaseNameInMetricsLabels }} {{ .Release.Name }}-{{ .Values.appLabel }}{{- else }} {{ .Values.appLabel }}{{- end }} service is experiencing high 5xx error rate.
         {{- if .Values.grafanaURL }}
-        dashboard: {{ .Values.grafanaURL }}/d/{{- if .Values.includeReleaseNameInMetricsLabels }}{{ .Release.Name }}-{{ .Values.appLabel }}{{- else }}{{ .Values.appLabel }}{{- end }}-overview
+        dashboard: {{ .Values.grafanaURL }}/d/{{ include "dashboard-uid" .}}
         {{- end }}
       labels:
             severity: critical
@@ -94,7 +34,7 @@ spec:
       for: 5m
       annotations:
         {{- if .Values.grafanaURL }}
-        dashboard: {{ .Values.grafanaURL }}/d/{{- if .Values.includeReleaseNameInMetricsLabels }}{{ .Release.Name }}-{{ .Values.appLabel }}{{- else }}{{ .Values.appLabel }}{{- end }}-overview
+        dashboard: {{ .Values.grafanaURL }}/d/{{ include "dashboard-uid" .}}
         {{- end }}
         description: {{- if .Values.includeReleaseNameInMetricsLabels }} {{ .Release.Name }}-{{ .Values.appLabel }}{{- else }} {{ .Values.appLabel }}{{- end }} service is experiencing high 4xx errors rate from last 5 minutes.
         summary: {{- if .Values.includeReleaseNameInMetricsLabels }} {{ .Release.Name }}-{{ .Values.appLabel }}{{- else }} {{ .Values.appLabel }}{{- end }} service is experiencing high 4xx error rate.
@@ -108,7 +48,7 @@ spec:
         description: {{ .Values.appLabel }} service is experiencing high 5xx errors rate from last 5 minutes.
         summary: {{ .Values.appLabel }} is experiencing high 5xx error rate.
         {{- if .Values.grafanaURL }}
-        dashboard: {{ .Values.grafanaURL }}/d/{{ .Values.appLabel }}-overview
+        dashboard: {{ .Values.grafanaURL }}/d/{{ include "dashboard-uid" .}}
         {{- end }}
       labels:
             severity: critical
@@ -119,7 +59,7 @@ spec:
         description: {{ .Values.appLabel }} service is experiencing high 4xx errors rate from last 5 minutes.
         summary: {{ .Values.appLabel }} service is experiencing high 4xx error rate.
         {{- if .Values.grafanaURL }}
-        dashboard: {{ .Values.grafanaURL }}/d/{{ .Values.appLabel }}-overview
+        dashboard: {{ .Values.grafanaURL }}/d/{{ include "dashboard-uid" .}}
         {{- end }}
       labels:
             severity: warning

--- a/charts/nopo11y/templates/defaultAlerts.yaml
+++ b/charts/nopo11y/templates/defaultAlerts.yaml
@@ -21,7 +21,7 @@ spec:
         description: {{- if .Values.includeReleaseNameInMetricsLabels }} {{ .Release.Name }}-{{ .Values.appLabel }}{{- else }} {{ .Values.appLabel }}{{- end }} service is experiencing high 5xx errors rate from last 5 minutes.
         summary: {{- if .Values.includeReleaseNameInMetricsLabels }} {{ .Release.Name }}-{{ .Values.appLabel }}{{- else }} {{ .Values.appLabel }}{{- end }} service is experiencing high 5xx error rate.
         {{- if .Values.grafanaURL }}
-        dashboard: {{ .Values.grafanaURL }}/d/{{ include "dashboard-uid" .}}
+        dashboard: {{ .Values.grafanaURL }}/d/{{ include "dashboard-uid" . }}
         {{- end }}
       labels:
             severity: critical
@@ -34,7 +34,7 @@ spec:
       for: 5m
       annotations:
         {{- if .Values.grafanaURL }}
-        dashboard: {{ .Values.grafanaURL }}/d/{{ include "dashboard-uid" .}}
+        dashboard: {{ .Values.grafanaURL }}/d/{{ include "dashboard-uid" . }}
         {{- end }}
         description: {{- if .Values.includeReleaseNameInMetricsLabels }} {{ .Release.Name }}-{{ .Values.appLabel }}{{- else }} {{ .Values.appLabel }}{{- end }} service is experiencing high 4xx errors rate from last 5 minutes.
         summary: {{- if .Values.includeReleaseNameInMetricsLabels }} {{ .Release.Name }}-{{ .Values.appLabel }}{{- else }} {{ .Values.appLabel }}{{- end }} service is experiencing high 4xx error rate.
@@ -48,7 +48,7 @@ spec:
         description: {{ .Values.appLabel }} service is experiencing high 5xx errors rate from last 5 minutes.
         summary: {{ .Values.appLabel }} is experiencing high 5xx error rate.
         {{- if .Values.grafanaURL }}
-        dashboard: {{ .Values.grafanaURL }}/d/{{ include "dashboard-uid" .}}
+        dashboard: {{ .Values.grafanaURL }}/d/{{ include "dashboard-uid" . }}
         {{- end }}
       labels:
             severity: critical
@@ -59,7 +59,7 @@ spec:
         description: {{ .Values.appLabel }} service is experiencing high 4xx errors rate from last 5 minutes.
         summary: {{ .Values.appLabel }} service is experiencing high 4xx error rate.
         {{- if .Values.grafanaURL }}
-        dashboard: {{ .Values.grafanaURL }}/d/{{ include "dashboard-uid" .}}
+        dashboard: {{ .Values.grafanaURL }}/d/{{ include "dashboard-uid" . }}
         {{- end }}
       labels:
             severity: warning

--- a/charts/nopo11y/templates/defaultDashboard.yaml
+++ b/charts/nopo11y/templates/defaultDashboard.yaml
@@ -1540,7 +1540,7 @@ data:
       "timepicker": {},
       "timezone": "",
       "title": "{{- if .Values.includeReleaseNameInMetricsLabels }}{{ title .Release.Name }}-{{ title .Values.appLabel }}{{- else }}{{ title .Values.appLabel }}{{- end }} Overview - Dashboard",
-      "uid": "{{- if .Values.includeReleaseNameInMetricsLabels }}{{ .Release.Name }}-{{ .Values.appLabel }}{{- else }}{{ .Values.appLabel }}{{- end }}-overview",
+      "uid": "{{ include "dashboard-uid" .}},
       "version": 10,
       "weekStart": ""
     }

--- a/charts/nopo11y/templates/defaultDashboard.yaml
+++ b/charts/nopo11y/templates/defaultDashboard.yaml
@@ -1540,7 +1540,7 @@ data:
       "timepicker": {},
       "timezone": "",
       "title": "{{- if .Values.includeReleaseNameInMetricsLabels }}{{ title .Release.Name }}-{{ title .Values.appLabel }}{{- else }}{{ title .Values.appLabel }}{{- end }} Overview - Dashboard",
-      "uid": "{{ include "dashboard-uid" .}},
+      "uid": "{{ include "dashboard-uid" . }},
       "version": 10,
       "weekStart": ""
     }


### PR DESCRIPTION
Updated nopo11y helm chart did below changes.
- Added helpers.tpl for grafana dashboard uid generation
- Remvoed Memory and CPU utilization alerts since those alerts are already there in nopo11y-stack
