### PR TITLE
Enabling jaeger monitoring

### DIFF
--- a/charts/nopo11y-stack/Chart.yaml
+++ b/charts/nopo11y-stack/Chart.yaml
@@ -28,7 +28,7 @@ dependencies:
 - condition: jaeger.enabled
   name: jaeger
   repository: ""
-  version: 1.0.0
+  version: 1.0.1
 - condition: prom2teams.enabled
   name: prom2teams
   repository: ""
@@ -48,4 +48,4 @@ dependencies:
 description: A Helm chart for observability stack
 name: nopo11y-stack
 type: application
-version: 1.5.0
+version: 1.5.1

--- a/charts/nopo11y-stack/charts/jaeger/Chart.yaml
+++ b/charts/nopo11y-stack/charts/jaeger/Chart.yaml
@@ -3,4 +3,4 @@ appVersion: 1.16.0
 description: A Helm chart for Jaeger for Istio
 name: jaeger
 type: application
-version: 1.0.0
+version: 1.0.1

--- a/charts/nopo11y-stack/charts/jaeger/dashboards/jaeger.json
+++ b/charts/nopo11y-stack/charts/jaeger/dashboards/jaeger.json
@@ -1,0 +1,931 @@
+{
+    "annotations": {
+       "list": [ ]
+    },
+    "editable": true,
+    "gnetId": null,
+    "graphTooltip": 0,
+    "hideControls": false,
+    "links": [ ],
+    "refresh": "10s",
+    "rows": [
+       {
+          "collapse": false,
+          "height": "250px",
+          "panels": [
+             {
+                "aliasColors": {
+                   "error": "#E24D42",
+                   "success": "#7EB26D"
+                },
+                "bars": false,
+                "dashLength": 10,
+                "dashes": false,
+                "datasource": "$datasource",
+                "fill": 10,
+                "id": 1,
+                "legend": {
+                   "avg": false,
+                   "current": false,
+                   "max": false,
+                   "min": false,
+                   "show": true,
+                   "total": false,
+                   "values": false
+                },
+                "lines": true,
+                "linewidth": 0,
+                "links": [ ],
+                "nullPointMode": "null as zero",
+                "percentage": false,
+                "pointradius": 5,
+                "points": false,
+                "renderer": "flot",
+                "seriesOverrides": [ ],
+                "spaceLength": 10,
+                "span": 6,
+                "stack": true,
+                "steppedLine": false,
+                "targets": [
+                   {
+                      "expr": "sum(rate(jaeger_tracer_reporter_spans_total{result=~\"dropped|err\"}[1m]))",
+                      "format": "time_series",
+                      "intervalFactor": 2,
+                      "legendFormat": "error",
+                      "refId": "A",
+                      "step": 10
+                   },
+                   {
+                      "expr": "sum(rate(jaeger_tracer_reporter_spans_total[1m])) - sum(rate(jaeger_tracer_reporter_spans_total{result=~\"dropped|err\"}[1m]))",
+                      "format": "time_series",
+                      "intervalFactor": 2,
+                      "legendFormat": "success",
+                      "refId": "B",
+                      "step": 10
+                   }
+                ],
+                "thresholds": [ ],
+                "timeFrom": null,
+                "timeShift": null,
+                "title": "span creation rate",
+                "tooltip": {
+                   "shared": true,
+                   "sort": 0,
+                   "value_type": "individual"
+                },
+                "type": "graph",
+                "xaxis": {
+                   "buckets": null,
+                   "mode": "time",
+                   "name": null,
+                   "show": true,
+                   "values": [ ]
+                },
+                "yaxes": [
+                   {
+                      "format": "short",
+                      "label": null,
+                      "logBase": 1,
+                      "max": null,
+                      "min": 0,
+                      "show": true
+                   },
+                   {
+                      "format": "short",
+                      "label": null,
+                      "logBase": 1,
+                      "max": null,
+                      "min": null,
+                      "show": false
+                   }
+                ]
+             },
+             {
+                "aliasColors": { },
+                "bars": false,
+                "dashLength": 10,
+                "dashes": false,
+                "datasource": "$datasource",
+                "fill": 10,
+                "id": 2,
+                "legend": {
+                   "avg": false,
+                   "current": false,
+                   "max": false,
+                   "min": false,
+                   "show": true,
+                   "total": false,
+                   "values": false
+                },
+                "lines": true,
+                "linewidth": 0,
+                "links": [ ],
+                "nullPointMode": "null as zero",
+                "percentage": false,
+                "pointradius": 5,
+                "points": false,
+                "renderer": "flot",
+                "seriesOverrides": [ ],
+                "spaceLength": 10,
+                "span": 6,
+                "stack": true,
+                "steppedLine": false,
+                "targets": [
+                   {
+                      "expr": "sum(rate(jaeger_tracer_reporter_spans_total{result=~\"dropped|err\"}[1m])) by (namespace) / sum(rate(jaeger_tracer_reporter_spans_total[1m])) by (namespace)",
+                      "format": "time_series",
+                      "intervalFactor": 2,
+                      "legendFormat": "{{namespace}}",
+                      "legendLink": null,
+                      "step": 10
+                   }
+                ],
+                "thresholds": [ ],
+                "timeFrom": null,
+                "timeShift": null,
+                "title": "% spans dropped",
+                "tooltip": {
+                   "shared": true,
+                   "sort": 0,
+                   "value_type": "individual"
+                },
+                "type": "graph",
+                "xaxis": {
+                   "buckets": null,
+                   "mode": "time",
+                   "name": null,
+                   "show": true,
+                   "values": [ ]
+                },
+                "yaxes": [
+                   {
+                      "format": "percentunit",
+                      "label": null,
+                      "logBase": 1,
+                      "max": 1,
+                      "min": 0,
+                      "show": true
+                   },
+                   {
+                      "format": "short",
+                      "label": null,
+                      "logBase": 1,
+                      "max": null,
+                      "min": null,
+                      "show": false
+                   }
+                ]
+             }
+          ],
+          "repeat": null,
+          "repeatIteration": null,
+          "repeatRowId": null,
+          "showTitle": true,
+          "title": "Services",
+          "titleSize": "h6"
+       },
+       {
+          "collapse": false,
+          "height": "250px",
+          "panels": [
+             {
+                "aliasColors": {
+                   "error": "#E24D42",
+                   "success": "#7EB26D"
+                },
+                "bars": false,
+                "dashLength": 10,
+                "dashes": false,
+                "datasource": "$datasource",
+                "fill": 10,
+                "id": 3,
+                "legend": {
+                   "avg": false,
+                   "current": false,
+                   "max": false,
+                   "min": false,
+                   "show": true,
+                   "total": false,
+                   "values": false
+                },
+                "lines": true,
+                "linewidth": 0,
+                "links": [ ],
+                "nullPointMode": "null as zero",
+                "percentage": false,
+                "pointradius": 5,
+                "points": false,
+                "renderer": "flot",
+                "seriesOverrides": [ ],
+                "spaceLength": 10,
+                "span": 6,
+                "stack": true,
+                "steppedLine": false,
+                "targets": [
+                   {
+                      "expr": "sum(rate(jaeger_agent_reporter_batches_failures_total[1m]))",
+                      "format": "time_series",
+                      "intervalFactor": 2,
+                      "legendFormat": "error",
+                      "refId": "A",
+                      "step": 10
+                   },
+                   {
+                      "expr": "sum(rate(jaeger_agent_reporter_batches_submitted_total[1m])) - sum(rate(jaeger_agent_reporter_batches_failures_total[1m]))",
+                      "format": "time_series",
+                      "intervalFactor": 2,
+                      "legendFormat": "success",
+                      "refId": "B",
+                      "step": 10
+                   }
+                ],
+                "thresholds": [ ],
+                "timeFrom": null,
+                "timeShift": null,
+                "title": "batch ingest rate",
+                "tooltip": {
+                   "shared": true,
+                   "sort": 0,
+                   "value_type": "individual"
+                },
+                "type": "graph",
+                "xaxis": {
+                   "buckets": null,
+                   "mode": "time",
+                   "name": null,
+                   "show": true,
+                   "values": [ ]
+                },
+                "yaxes": [
+                   {
+                      "format": "short",
+                      "label": null,
+                      "logBase": 1,
+                      "max": null,
+                      "min": 0,
+                      "show": true
+                   },
+                   {
+                      "format": "short",
+                      "label": null,
+                      "logBase": 1,
+                      "max": null,
+                      "min": null,
+                      "show": false
+                   }
+                ]
+             },
+             {
+                "aliasColors": { },
+                "bars": false,
+                "dashLength": 10,
+                "dashes": false,
+                "datasource": "$datasource",
+                "fill": 10,
+                "id": 4,
+                "legend": {
+                   "avg": false,
+                   "current": false,
+                   "max": false,
+                   "min": false,
+                   "show": true,
+                   "total": false,
+                   "values": false
+                },
+                "lines": true,
+                "linewidth": 0,
+                "links": [ ],
+                "nullPointMode": "null as zero",
+                "percentage": false,
+                "pointradius": 5,
+                "points": false,
+                "renderer": "flot",
+                "seriesOverrides": [ ],
+                "spaceLength": 10,
+                "span": 6,
+                "stack": true,
+                "steppedLine": false,
+                "targets": [
+                   {
+                      "expr": "sum(rate(jaeger_agent_reporter_batches_failures_total[1m])) by (cluster) / sum(rate(jaeger_agent_reporter_batches_submitted_total[1m])) by (cluster)",
+                      "format": "time_series",
+                      "intervalFactor": 2,
+                      "legendFormat": "{{cluster}}",
+                      "legendLink": null,
+                      "step": 10
+                   }
+                ],
+                "thresholds": [ ],
+                "timeFrom": null,
+                "timeShift": null,
+                "title": "% batches dropped",
+                "tooltip": {
+                   "shared": true,
+                   "sort": 0,
+                   "value_type": "individual"
+                },
+                "type": "graph",
+                "xaxis": {
+                   "buckets": null,
+                   "mode": "time",
+                   "name": null,
+                   "show": true,
+                   "values": [ ]
+                },
+                "yaxes": [
+                   {
+                      "format": "percentunit",
+                      "label": null,
+                      "logBase": 1,
+                      "max": 1,
+                      "min": 0,
+                      "show": true
+                   },
+                   {
+                      "format": "short",
+                      "label": null,
+                      "logBase": 1,
+                      "max": null,
+                      "min": null,
+                      "show": false
+                   }
+                ]
+             }
+          ],
+          "repeat": null,
+          "repeatIteration": null,
+          "repeatRowId": null,
+          "showTitle": true,
+          "title": "Agent",
+          "titleSize": "h6"
+       },
+       {
+          "collapse": false,
+          "height": "250px",
+          "panels": [
+             {
+                "aliasColors": {
+                   "error": "#E24D42",
+                   "success": "#7EB26D"
+                },
+                "bars": false,
+                "dashLength": 10,
+                "dashes": false,
+                "datasource": "$datasource",
+                "fill": 10,
+                "id": 5,
+                "legend": {
+                   "avg": false,
+                   "current": false,
+                   "max": false,
+                   "min": false,
+                   "show": true,
+                   "total": false,
+                   "values": false
+                },
+                "lines": true,
+                "linewidth": 0,
+                "links": [ ],
+                "nullPointMode": "null as zero",
+                "percentage": false,
+                "pointradius": 5,
+                "points": false,
+                "renderer": "flot",
+                "seriesOverrides": [ ],
+                "spaceLength": 10,
+                "span": 6,
+                "stack": true,
+                "steppedLine": false,
+                "targets": [
+                   {
+                      "expr": "sum(rate(jaeger_collector_spans_dropped_total[1m]))",
+                      "format": "time_series",
+                      "intervalFactor": 2,
+                      "legendFormat": "error",
+                      "refId": "A",
+                      "step": 10
+                   },
+                   {
+                      "expr": "sum(rate(jaeger_collector_spans_received_total[1m])) - sum(rate(jaeger_collector_spans_dropped_total[1m]))",
+                      "format": "time_series",
+                      "intervalFactor": 2,
+                      "legendFormat": "success",
+                      "refId": "B",
+                      "step": 10
+                   }
+                ],
+                "thresholds": [ ],
+                "timeFrom": null,
+                "timeShift": null,
+                "title": "span ingest rate",
+                "tooltip": {
+                   "shared": true,
+                   "sort": 0,
+                   "value_type": "individual"
+                },
+                "type": "graph",
+                "xaxis": {
+                   "buckets": null,
+                   "mode": "time",
+                   "name": null,
+                   "show": true,
+                   "values": [ ]
+                },
+                "yaxes": [
+                   {
+                      "format": "short",
+                      "label": null,
+                      "logBase": 1,
+                      "max": null,
+                      "min": 0,
+                      "show": true
+                   },
+                   {
+                      "format": "short",
+                      "label": null,
+                      "logBase": 1,
+                      "max": null,
+                      "min": null,
+                      "show": false
+                   }
+                ]
+             },
+             {
+                "aliasColors": { },
+                "bars": false,
+                "dashLength": 10,
+                "dashes": false,
+                "datasource": "$datasource",
+                "fill": 10,
+                "id": 6,
+                "legend": {
+                   "avg": false,
+                   "current": false,
+                   "max": false,
+                   "min": false,
+                   "show": true,
+                   "total": false,
+                   "values": false
+                },
+                "lines": true,
+                "linewidth": 0,
+                "links": [ ],
+                "nullPointMode": "null as zero",
+                "percentage": false,
+                "pointradius": 5,
+                "points": false,
+                "renderer": "flot",
+                "seriesOverrides": [ ],
+                "spaceLength": 10,
+                "span": 6,
+                "stack": true,
+                "steppedLine": false,
+                "targets": [
+                   {
+                      "expr": "sum(rate(jaeger_collector_spans_dropped_total[1m])) by (instance) / sum(rate(jaeger_collector_spans_received_total[1m])) by (instance)",
+                      "format": "time_series",
+                      "intervalFactor": 2,
+                      "legendFormat": "{{instance}}",
+                      "legendLink": null,
+                      "step": 10
+                   }
+                ],
+                "thresholds": [ ],
+                "timeFrom": null,
+                "timeShift": null,
+                "title": "% spans dropped",
+                "tooltip": {
+                   "shared": true,
+                   "sort": 0,
+                   "value_type": "individual"
+                },
+                "type": "graph",
+                "xaxis": {
+                   "buckets": null,
+                   "mode": "time",
+                   "name": null,
+                   "show": true,
+                   "values": [ ]
+                },
+                "yaxes": [
+                   {
+                      "format": "percentunit",
+                      "label": null,
+                      "logBase": 1,
+                      "max": 1,
+                      "min": 0,
+                      "show": true
+                   },
+                   {
+                      "format": "short",
+                      "label": null,
+                      "logBase": 1,
+                      "max": null,
+                      "min": null,
+                      "show": false
+                   }
+                ]
+             }
+          ],
+          "repeat": null,
+          "repeatIteration": null,
+          "repeatRowId": null,
+          "showTitle": true,
+          "title": "Collector",
+          "titleSize": "h6"
+       },
+       {
+          "collapse": false,
+          "height": "250px",
+          "panels": [
+             {
+                "aliasColors": { },
+                "bars": false,
+                "dashLength": 10,
+                "dashes": false,
+                "datasource": "$datasource",
+                "fill": 10,
+                "id": 7,
+                "legend": {
+                   "avg": false,
+                   "current": false,
+                   "max": false,
+                   "min": false,
+                   "show": true,
+                   "total": false,
+                   "values": false
+                },
+                "lines": true,
+                "linewidth": 0,
+                "links": [ ],
+                "nullPointMode": "null as zero",
+                "percentage": false,
+                "pointradius": 5,
+                "points": false,
+                "renderer": "flot",
+                "seriesOverrides": [ ],
+                "spaceLength": 10,
+                "span": 6,
+                "stack": true,
+                "steppedLine": false,
+                "targets": [
+                   {
+                      "expr": "jaeger_collector_queue_length",
+                      "format": "time_series",
+                      "intervalFactor": 2,
+                      "legendFormat": "{{instance}}",
+                      "legendLink": null,
+                      "step": 10
+                   }
+                ],
+                "thresholds": [ ],
+                "timeFrom": null,
+                "timeShift": null,
+                "title": "span queue length",
+                "tooltip": {
+                   "shared": true,
+                   "sort": 0,
+                   "value_type": "individual"
+                },
+                "type": "graph",
+                "xaxis": {
+                   "buckets": null,
+                   "mode": "time",
+                   "name": null,
+                   "show": true,
+                   "values": [ ]
+                },
+                "yaxes": [
+                   {
+                      "format": "short",
+                      "label": null,
+                      "logBase": 1,
+                      "max": null,
+                      "min": 0,
+                      "show": true
+                   },
+                   {
+                      "format": "short",
+                      "label": null,
+                      "logBase": 1,
+                      "max": null,
+                      "min": null,
+                      "show": false
+                   }
+                ]
+             },
+             {
+                "aliasColors": { },
+                "bars": false,
+                "dashLength": 10,
+                "dashes": false,
+                "datasource": "$datasource",
+                "fill": 1,
+                "id": 8,
+                "legend": {
+                   "avg": false,
+                   "current": false,
+                   "max": false,
+                   "min": false,
+                   "show": true,
+                   "total": false,
+                   "values": false
+                },
+                "lines": true,
+                "linewidth": 1,
+                "links": [ ],
+                "nullPointMode": "null as zero",
+                "percentage": false,
+                "pointradius": 5,
+                "points": false,
+                "renderer": "flot",
+                "seriesOverrides": [ ],
+                "spaceLength": 10,
+                "span": 6,
+                "stack": false,
+                "steppedLine": false,
+                "targets": [
+                   {
+                      "expr": "histogram_quantile(0.95, sum(rate(jaeger_collector_in_queue_latency_bucket[1m])) by (le, instance))",
+                      "format": "time_series",
+                      "intervalFactor": 2,
+                      "legendFormat": "{{instance}}",
+                      "legendLink": null,
+                      "step": 10
+                   }
+                ],
+                "thresholds": [ ],
+                "timeFrom": null,
+                "timeShift": null,
+                "title": "span queue time - 95 percentile",
+                "tooltip": {
+                   "shared": true,
+                   "sort": 0,
+                   "value_type": "individual"
+                },
+                "type": "graph",
+                "xaxis": {
+                   "buckets": null,
+                   "mode": "time",
+                   "name": null,
+                   "show": true,
+                   "values": [ ]
+                },
+                "yaxes": [
+                   {
+                      "format": "short",
+                      "label": null,
+                      "logBase": 1,
+                      "max": null,
+                      "min": 0,
+                      "show": true
+                   },
+                   {
+                      "format": "short",
+                      "label": null,
+                      "logBase": 1,
+                      "max": null,
+                      "min": null,
+                      "show": false
+                   }
+                ]
+             }
+          ],
+          "repeat": null,
+          "repeatIteration": null,
+          "repeatRowId": null,
+          "showTitle": true,
+          "title": "Collector Queue",
+          "titleSize": "h6"
+       },
+       {
+          "collapse": false,
+          "height": "250px",
+          "panels": [
+             {
+                "aliasColors": {
+                   "error": "#E24D42",
+                   "success": "#7EB26D"
+                },
+                "bars": false,
+                "dashLength": 10,
+                "dashes": false,
+                "datasource": "$datasource",
+                "fill": 10,
+                "id": 9,
+                "legend": {
+                   "avg": false,
+                   "current": false,
+                   "max": false,
+                   "min": false,
+                   "show": true,
+                   "total": false,
+                   "values": false
+                },
+                "lines": true,
+                "linewidth": 0,
+                "links": [ ],
+                "nullPointMode": "null as zero",
+                "percentage": false,
+                "pointradius": 5,
+                "points": false,
+                "renderer": "flot",
+                "seriesOverrides": [ ],
+                "spaceLength": 10,
+                "span": 6,
+                "stack": true,
+                "steppedLine": false,
+                "targets": [
+                   {
+                      "expr": "sum(rate(jaeger_query_requests_total{result=\"err\"}[1m]))",
+                      "format": "time_series",
+                      "intervalFactor": 2,
+                      "legendFormat": "error",
+                      "refId": "A",
+                      "step": 10
+                   },
+                   {
+                      "expr": "sum(rate(jaeger_query_requests_total[1m])) - sum(rate(jaeger_query_requests_total{result=\"err\"}[1m]))",
+                      "format": "time_series",
+                      "intervalFactor": 2,
+                      "legendFormat": "success",
+                      "refId": "B",
+                      "step": 10
+                   }
+                ],
+                "thresholds": [ ],
+                "timeFrom": null,
+                "timeShift": null,
+                "title": "qps",
+                "tooltip": {
+                   "shared": true,
+                   "sort": 0,
+                   "value_type": "individual"
+                },
+                "type": "graph",
+                "xaxis": {
+                   "buckets": null,
+                   "mode": "time",
+                   "name": null,
+                   "show": true,
+                   "values": [ ]
+                },
+                "yaxes": [
+                   {
+                      "format": "short",
+                      "label": null,
+                      "logBase": 1,
+                      "max": null,
+                      "min": 0,
+                      "show": true
+                   },
+                   {
+                      "format": "short",
+                      "label": null,
+                      "logBase": 1,
+                      "max": null,
+                      "min": null,
+                      "show": false
+                   }
+                ]
+             },
+             {
+                "aliasColors": { },
+                "bars": false,
+                "dashLength": 10,
+                "dashes": false,
+                "datasource": "$datasource",
+                "fill": 10,
+                "id": 10,
+                "legend": {
+                   "avg": false,
+                   "current": false,
+                   "max": false,
+                   "min": false,
+                   "show": true,
+                   "total": false,
+                   "values": false
+                },
+                "lines": true,
+                "linewidth": 0,
+                "links": [ ],
+                "nullPointMode": "null as zero",
+                "percentage": false,
+                "pointradius": 5,
+                "points": false,
+                "renderer": "flot",
+                "seriesOverrides": [ ],
+                "spaceLength": 10,
+                "span": 6,
+                "stack": true,
+                "steppedLine": false,
+                "targets": [
+                   {
+                      "expr": "histogram_quantile(0.99, sum(rate(jaeger_query_latency_bucket[1m])) by (le, instance))",
+                      "format": "time_series",
+                      "intervalFactor": 2,
+                      "legendFormat": "{{instance}}",
+                      "legendLink": null,
+                      "step": 10
+                   }
+                ],
+                "thresholds": [ ],
+                "timeFrom": null,
+                "timeShift": null,
+                "title": "latency - 99 percentile",
+                "tooltip": {
+                   "shared": true,
+                   "sort": 0,
+                   "value_type": "individual"
+                },
+                "type": "graph",
+                "xaxis": {
+                   "buckets": null,
+                   "mode": "time",
+                   "name": null,
+                   "show": true,
+                   "values": [ ]
+                },
+                "yaxes": [
+                   {
+                      "format": "short",
+                      "label": null,
+                      "logBase": 1,
+                      "max": null,
+                      "min": 0,
+                      "show": true
+                   },
+                   {
+                      "format": "short",
+                      "label": null,
+                      "logBase": 1,
+                      "max": null,
+                      "min": null,
+                      "show": false
+                   }
+                ]
+             }
+          ],
+          "repeat": null,
+          "repeatIteration": null,
+          "repeatRowId": null,
+          "showTitle": true,
+          "title": "Query",
+          "titleSize": "h6"
+       }
+    ],
+    "schemaVersion": 14,
+    "style": "dark",
+    "tags": [ ],
+    "templating": {
+       "list": [
+          {
+             "current": {
+                "text": "Prometheus",
+                "value": "Prometheus"
+             },
+             "hide": 0,
+             "label": null,
+             "name": "datasource",
+             "options": [ ],
+             "query": "prometheus",
+             "refresh": 1,
+             "regex": "",
+             "type": "datasource"
+          }
+       ]
+    },
+    "time": {
+       "from": "now-1h",
+       "to": "now"
+    },
+    "timepicker": {
+       "refresh_intervals": [
+          "5s",
+          "10s",
+          "30s",
+          "1m",
+          "5m",
+          "15m",
+          "30m",
+          "1h",
+          "2h",
+          "1d"
+       ],
+       "time_options": [
+          "5m",
+          "15m",
+          "1h",
+          "6h",
+          "12h",
+          "24h",
+          "2d",
+          "7d",
+          "30d"
+       ]
+    },
+    "timezone": "utc",
+    "title": "Jaeger Overview",
+    "uid": "",
+    "version": 0
+ }

--- a/charts/nopo11y-stack/charts/jaeger/templates/dashboard.yaml
+++ b/charts/nopo11y-stack/charts/jaeger/templates/dashboard.yaml
@@ -1,0 +1,16 @@
+{{- if .Values.jaeger.serviceMonitor.enabled }}
+{{- range $file, $_ := .Files.Glob "dashboards/*" }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: grafana-dashboard-{{ base $file |trimSuffix ".json" }}
+  namespace: {{ $.Release.Namespace }}
+  labels:
+    grafana_dashboard: "1"
+data:
+{{- base $file | nindent 2 }}: |-
+{{ $.Files.Get $file | indent 6 }}
+
+---
+{{- end }}
+{{- end }}

--- a/charts/nopo11y-stack/charts/jaeger/templates/service.yaml
+++ b/charts/nopo11y-stack/charts/jaeger/templates/service.yaml
@@ -17,6 +17,10 @@ spec:
       port: 16685
       protocol: TCP
       targetPort: 16685
+    - name: metrics
+      port: 14269
+      protocol: TCP
+      targetPort: 14269
   selector:
     app: jaeger
 ---

--- a/charts/nopo11y-stack/charts/jaeger/templates/servicemonitor.yaml
+++ b/charts/nopo11y-stack/charts/jaeger/templates/servicemonitor.yaml
@@ -1,0 +1,22 @@
+{{- if .Values.jaeger.serviceMonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  {{- if .Values.jaeger.serviceMonitor.labels }}
+  labels:
+  {{- toYaml .Values.jaeger.serviceMonitor.labels | nindent 4 }}
+  {{- end }}
+  name: {{ .Release.Name }}-tracing
+  namespace: {{ .Release.Namespace }}
+spec:
+  endpoints:
+  - port: metrics
+    scheme: http
+    path: "/metrics"
+  namespaceSelector:
+    matchNames:
+    - {{ .Release.Namespace }}
+  selector:
+    matchLabels:
+      app: jaeger
+{{- end }}

--- a/charts/nopo11y-stack/charts/jaeger/values.yaml
+++ b/charts/nopo11y-stack/charts/jaeger/values.yaml
@@ -16,3 +16,8 @@ jaeger:
     storageClassName: "default"
     size: 8Gi
   tracesTTL: "168h"
+  serviceMonitor:
+    enabled: false
+    labels: {}
+      # app: "jaeger"
+      # env: "Dev"

--- a/charts/nopo11y-stack/values.yaml
+++ b/charts/nopo11y-stack/values.yaml
@@ -15618,6 +15618,11 @@ jaeger:
       storageClassName: "default"
       size: 8Gi
     tracesTTL: "168h"
+    serviceMonitr:
+      enabled: false
+      labels: {}
+        # app: jaeger
+        # env: Dev
 
 ### Prom2teams
 ### This Helm chart is taken from here https://github.com/idealista/prom2teams, please check how to configure and use prom2teams.


### PR DESCRIPTION
Updates
- Added service monitor resource for scraping jaeger metrics
- Added jaeger overview grafana dashboard
- Updated nopo11y-stack chart version to 1.5.1