### PR TITLE
Kube prometheus stack chart upgrade

### DIFF
--- a/charts/nopo11y-stack/Chart.yaml
+++ b/charts/nopo11y-stack/Chart.yaml
@@ -4,7 +4,7 @@ dependencies:
 - condition: kube-prometheus-stack.enabled
   name: kube-prometheus-stack
   repository: https://prometheus-community.github.io/helm-charts
-  version: 58.5.2
+  version: 67.5.0
 - condition: thanos.enabled
   name: thanos
   repository: https://charts.bitnami.com/bitnami
@@ -48,4 +48,4 @@ dependencies:
 description: A Helm chart for observability stack
 name: nopo11y-stack
 type: application
-version: 1.7.2
+version: 2.0.0

--- a/charts/nopo11y-stack/values.yaml
+++ b/charts/nopo11y-stack/values.yaml
@@ -177,6 +177,10 @@ kube-prometheus-stack:
     ## Prefix for runbook URLs. Use this to override the first part of the runbookURLs that is common to all rules.
     runbookUrl: "https://runbooks.prometheus-operator.dev/runbooks"
 
+    node:
+      fsSelector: 'fstype!=""'
+      # fsSelector: 'fstype=~"ext[234]|btrfs|xfs|zfs"'
+
     ## Disabled PrometheusRule alerts
     disabled: {}
     # KubeAPIDown: true
@@ -277,6 +281,10 @@ kube-prometheus-stack:
     ## Api that prometheus will use to communicate with alertmanager. Possible values are v1, v2
     ##
     apiVersion: v2
+
+    ## @param alertmanager.enableFeatures Enable access to Alertmanager disabled features.
+    ##
+    enableFeatures: []
 
     ## Service account for Alertmanager to use.
     ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/
@@ -423,6 +431,42 @@ kube-prometheus-stack:
       # - secretName: alertmanager-general-tls
       #   hosts:
       #   - alertmanager.example.com
+
+    # -- BETA: Configure the gateway routes for the chart here.
+    # More routes can be added by adding a dictionary key like the 'main' route.
+    # Be aware that this is an early beta of this feature,
+    # kube-prometheus-stack does not guarantee this works and is subject to change.
+    # Being BETA this can/will change in the future without notice, do not use unless you want to take that risk
+    # [[ref]](https://gateway-api.sigs.k8s.io/references/spec/#gateway.networking.k8s.io%2fv1alpha2)
+    route:
+      main:
+        # -- Enables or disables the route
+        enabled: false
+
+        # -- Set the route apiVersion, e.g. gateway.networking.k8s.io/v1 or gateway.networking.k8s.io/v1alpha2
+        apiVersion: gateway.networking.k8s.io/v1
+        # -- Set the route kind
+        # Valid options are GRPCRoute, HTTPRoute, TCPRoute, TLSRoute, UDPRoute
+        kind: HTTPRoute
+
+        annotations: {}
+        labels: {}
+
+        hostnames: []
+        # - my-filter.example.com
+        parentRefs: []
+        # - name: acme-gw
+
+        matches:
+          - path:
+              type: PathPrefix
+              value: /
+
+        ## Filters define the filters that are applied to requests that match this rule.
+        filters: []
+
+        ## Additional custom rules that can be added to the route
+        additionalRules: []
 
     ## Configuration for Alertmanager secret
     ##
@@ -643,6 +687,16 @@ kube-prometheus-stack:
     ## ref: https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api.md#alertmanagerspec
     ##
     alertmanagerSpec:
+      ## Statefulset's persistent volume claim retention policy
+      ## whenDeleted and whenScaled determine whether
+      ## statefulset's PVCs are deleted (true) or retained (false)
+      ## on scaling down and deleting statefulset, respectively.
+      ## Requires Kubernetes version 1.27.0+.
+      ## Ref: https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#persistentvolumeclaim-retention
+      persistentVolumeClaimRetentionPolicy: {}
+      #  whenDeleted: Retain
+      #  whenScaled: Retain
+
       ## Standard object's metadata. More info: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#metadata
       ## Metadata Labels and Annotations gets propagated to the Alertmanager pods.
       ##
@@ -762,7 +816,7 @@ kube-prometheus-stack:
       #     resources:
       #       requests:
       #         storage: 50Gi
-      #     selector: {}
+      #   selector: {}
 
 
       ## The external URL the Alertmanager instances will be available under. This is necessary to generate correct URLs. This is necessary if Alertmanager is not served from root of a DNS name. string  false
@@ -802,7 +856,7 @@ kube-prometheus-stack:
       ## The value "hard" means that the scheduler is *required* to not schedule two replica pods onto the same node.
       ## The value "" will disable pod anti-affinity so that no anti-affinity rules will be configured.
       ##
-      podAntiAffinity: ""
+      podAntiAffinity: "soft"
 
       ## If anti-affinity is enabled sets the topologyKey to use for anti-affinity.
       ## This can be changed to, for example, failure-domain.beta.kubernetes.io/zone
@@ -917,6 +971,9 @@ kube-prometheus-stack:
       ## clusterPushpullInterval determines interval between pushpull attempts.
       ## Needs to be specified as GoDuration, a time duration that can be parsed by Go’s time.ParseDuration() (e.g. 45ms, 30s, 1m, 1h20m15s)
       clusterPushpullInterval: ""
+
+      ## clusterLabel defines the identifier that uniquely identifies the Alertmanager cluster.
+      clusterLabel: ""
 
       ## ForceEnableClusterMode ensures Alertmanager does not deactivate the cluster mode when running with a single replica.
       ## Use case is e.g. spanning an Alertmanager cluster across Kubernetes clusters with a single replica in each.
@@ -1063,6 +1120,7 @@ kube-prometheus-stack:
         defaultDatasourceEnabled: true
         isDefaultDatasource: true
 
+        name: Prometheus
         uid: prometheus
 
         ## URL of prometheus datasource
@@ -1097,6 +1155,7 @@ kube-prometheus-stack:
           # traceIdLabelName: trace_id
         alertmanager:
           enabled: true
+          name: Alertmanager
           uid: alertmanager
           handleGrafanaManagedAlerts: false
           implementation: prometheus
@@ -1117,7 +1176,8 @@ kube-prometheus-stack:
     # - name: prometheus-sample
     #   access: proxy
     #   basicAuth: true
-    #   basicAuthPassword: pass
+    #   secureJsonData:
+    #       basicAuthPassword: pass
     #   basicAuthUser: daco
     #   editable: false
     #   jsonData:
@@ -1127,10 +1187,17 @@ kube-prometheus-stack:
     #   url: https://{{ printf "%s-prometheus.svc" .Release.Name }}:9090
     #   version: 1
 
+    # Flag to mark provisioned data sources for deletion if they are no longer configured.
+    # It takes no effect if data sources are already listed in the deleteDatasources section.
+    # ref: https://grafana.com/docs/grafana/latest/administration/provisioning/#example-data-source-config-file
+    prune: false
+
     ## Passed to grafana subchart and used by servicemonitor below
     ##
     service:
       portName: http-web
+      ipFamilies: []
+      ipFamilyPolicy: ""
 
     serviceMonitor:
       # If true, a ServiceMonitor CRD is created for a prometheus operator
@@ -1244,6 +1311,10 @@ kube-prometheus-stack:
       additionalLabels: {}
       #  foo: bar
 
+      ## defines the labels which are transferred from the associated Kubernetes Service object onto the ingested metrics.
+      ## https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api.md#servicemonitor
+      targetLabels: []
+
   ## Component scraping the kubelet and kubelet-hosted cAdvisor
   ##
   kubelet:
@@ -1267,6 +1338,11 @@ kube-prometheus-stack:
       ## If true, Prometheus ingests metrics with timestamp provided by exporter. If false, Prometheus ingests metrics with timestamp of scrape.
       ##
       honorTimestamps: true
+
+      ## If true, defines whether Prometheus tracks staleness of the metrics that have an explicit timestamp present in scraped data. Has no effect if `honorTimestamps` is false.
+      ## We recommend enabling this if you want the best possible accuracy for container_ metrics scraped from cadvisor.
+      ## For more details see: https://github.com/prometheus-community/helm-charts/pull/5063#issuecomment-2545374849
+      trackTimestampsStaleness: true
 
       ## SampleLimit defines per-scrape limit on number of scraped samples that will be accepted.
       ##
@@ -1297,9 +1373,11 @@ kube-prometheus-stack:
       ##
       https: true
 
-      ## Enable scraping /metrics/cadvisor from kubelet's service
+      ## Skip TLS certificate validation when scraping.
+      ## This is enabled by default because kubelet serving certificate deployed by kubeadm is by default self-signed
+      ## ref: https://kubernetes.io/docs/tasks/administer-cluster/kubeadm/kubeadm-certs/#kubelet-serving-certs
       ##
-      cAdvisor: true
+      insecureSkipVerify: true
 
       ## Enable scraping /metrics/probes from kubelet's service
       ##
@@ -1311,7 +1389,18 @@ kube-prometheus-stack:
       resource: false
       # From kubernetes 1.18, /metrics/resource/v1alpha1 renamed to /metrics/resource
       resourcePath: "/metrics/resource/v1alpha1"
+      ## Configure the scrape interval for resource metrics. This is configured to the default Kubelet cAdvisor
+      ## minimum housekeeping interval in order to avoid missing samples. Note, this value is ignored
+      ## if kubelet.serviceMonitor.interval is not empty.
+      resourceInterval: 10s
 
+      ## Enable scraping /metrics/cadvisor from kubelet's service
+      ##
+      cAdvisor: true
+      ## Configure the scrape interval for cAdvisor. This is configured to the default Kubelet cAdvisor
+      ## minimum housekeeping interval in order to avoid missing samples. Note, this value is ignored
+      ## if kubelet.serviceMonitor.interval is not empty.
+      cAdvisorInterval: 10s
       ## MetricRelabelConfigs to apply to samples after scraping, but before ingestion.
       ## ref: https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api.md#relabelconfig
       ##
@@ -1444,6 +1533,10 @@ kube-prometheus-stack:
       additionalLabels: {}
       #  foo: bar
 
+      ## defines the labels which are transferred from the associated Kubernetes Service object onto the ingested metrics.
+      ## https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api.md#servicemonitor
+      targetLabels: []
+
   ## Component scraping the kube controller manager
   ##
   kubeControllerManager:
@@ -1547,6 +1640,10 @@ kube-prometheus-stack:
       additionalLabels: {}
       #  foo: bar
 
+      ## defines the labels which are transferred from the associated Kubernetes Service object onto the ingested metrics.
+      ## https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api.md#servicemonitor
+      targetLabels: []
+
   ## Component scraping coreDns. Use either this or kubeDns
   ##
   coreDns:
@@ -1624,6 +1721,10 @@ kube-prometheus-stack:
       ##
       additionalLabels: {}
       #  foo: bar
+
+      ## defines the labels which are transferred from the associated Kubernetes Service object onto the ingested metrics.
+      ## https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api.md#servicemonitor
+      targetLabels: []
 
   ## Component scraping kubeDns. Use either this or coreDns
   ##
@@ -1718,6 +1819,10 @@ kube-prometheus-stack:
       ##
       additionalLabels: {}
       #  foo: bar
+
+      ## defines the labels which are transferred from the associated Kubernetes Service object onto the ingested metrics.
+      ## https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api.md#servicemonitor
+      targetLabels: []
 
   ## Component scraping etcd
   ##
@@ -1824,6 +1929,10 @@ kube-prometheus-stack:
       additionalLabels: {}
       #  foo: bar
 
+      ## defines the labels which are transferred from the associated Kubernetes Service object onto the ingested metrics.
+      ## https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api.md#servicemonitor
+      targetLabels: []
+
   ## Component scraping kube scheduler
   ##
   kubeScheduler:
@@ -1926,6 +2035,10 @@ kube-prometheus-stack:
       additionalLabels: {}
       #  foo: bar
 
+      ## defines the labels which are transferred from the associated Kubernetes Service object onto the ingested metrics.
+      ## https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api.md#servicemonitor
+      targetLabels: []
+
   ## Component scraping kube proxy
   ##
   kubeProxy:
@@ -2014,6 +2127,10 @@ kube-prometheus-stack:
       additionalLabels: {}
       #  foo: bar
 
+      ## defines the labels which are transferred from the associated Kubernetes Service object onto the ingested metrics.
+      ## https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api.md#servicemonitor
+      targetLabels: []
+
   ## Component scraping kube state metrics
   ##
   kubeStateMetrics:
@@ -2095,6 +2212,8 @@ kube-prometheus-stack:
     operatingSystems:
       linux:
         enabled: true
+      aix:
+        enabled: true
       darwin:
         enabled: true
 
@@ -2120,6 +2239,9 @@ kube-prometheus-stack:
         enabled: false
         ipFamilies: ["IPv6", "IPv4"]
         ipFamilyPolicy: "PreferDualStack"
+      labels:
+        jobLabel: node-exporter
+
     prometheus:
       monitor:
         enabled: true
@@ -2178,6 +2300,12 @@ kube-prometheus-stack:
         #   targetLabel: nodename
         #   replacement: $1
         #   action: replace
+
+        ## Attach node metadata to discovered targets. Requires Prometheus v2.35.0 and above.
+        ##
+        # attachMetadata:
+        #   node: false
+
     rbac:
       ## If true, create PSPs for node-exporter
       ##
@@ -2208,6 +2336,25 @@ kube-prometheus-stack:
       # The default webhook port is 10250 in order to work out-of-the-box in GKE private clusters and avoid adding firewall rules.
       internalPort: 10250
 
+    ## Liveness probe for the prometheusOperator deployment
+    ##
+    livenessProbe:
+      enabled: true
+      failureThreshold: 3
+      initialDelaySeconds: 0
+      periodSeconds: 10
+      successThreshold: 1
+      timeoutSeconds: 1
+    ## Readiness probe for the prometheusOperator deployment
+    ##
+    readinessProbe:
+      enabled: true
+      failureThreshold: 3
+      initialDelaySeconds: 0
+      periodSeconds: 10
+      successThreshold: 1
+      timeoutSeconds: 1
+
     ## Admission webhook support for PrometheusRules resources added in Prometheus Operator 0.30 can be enabled to prevent incorrectly formatted
     ## rules from making their way into prometheus and potentially preventing the container from starting
     admissionWebhooks:
@@ -2229,6 +2376,15 @@ kube-prometheus-stack:
       #   argocd.argoproj.io/hook-delete-policy: HookSucceeded
 
       namespaceSelector: {}
+      objectSelector: {}
+
+      mutatingWebhookConfiguration:
+        annotations: {}
+        #   argocd.argoproj.io/hook: PreSync
+
+      validatingWebhookConfiguration:
+        annotations: {}
+        #   argocd.argoproj.io/hook: PreSync
 
       deployment:
         enabled: false
@@ -2263,6 +2419,7 @@ kube-prometheus-stack:
         ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/
         ##
         serviceAccount:
+          annotations: {}
           automountServiceAccountToken: false
           create: true
           name: ""
@@ -2460,6 +2617,7 @@ kube-prometheus-stack:
         ## Provide a priority class name to the webhook patching job
         ##
         priorityClassName: ""
+        ttlSecondsAfterFinished: 60
         annotations: {}
         #   argocd.argoproj.io/hook: PreSync
         #   argocd.argoproj.io/hook-delete-policy: HookSucceeded
@@ -2478,6 +2636,13 @@ kube-prometheus-stack:
           runAsUser: 2000
           seccompProfile:
             type: RuntimeDefault
+        ## Service account for Prometheus Operator Webhook Job Patch to use.
+        ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/
+        ##
+        serviceAccount:
+          create: true
+          annotations: {}
+          automountServiceAccountToken: true
 
       # Security context for create job container
       createSecretJob:
@@ -2558,6 +2723,7 @@ kube-prometheus-stack:
       create: true
       name: ""
       automountServiceAccountToken: true
+      annotations: {}
 
     ## Configuration for Prometheus operator service
     ##
@@ -2637,6 +2803,16 @@ kube-prometheus-stack:
       selector: ""
       ## Use '{{ template "kube-prometheus-stack.fullname" . }}-kubelet' by default
       name: ""
+
+    ## Create Endpoints objects for kubelet targets.
+    kubeletEndpointsEnabled: true
+    ## Create EndpointSlice objects for kubelet targets.
+    kubeletEndpointSliceEnabled: false
+
+    ## Extra arguments to pass to prometheusOperator
+    # https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/operator.md
+    extraArgs: []
+    #  - --labels="cluster=talos-cluster"
 
     ## Create a servicemonitor for the operator
     ##
@@ -2852,7 +3028,7 @@ kube-prometheus-stack:
     thanosImage:
       registry: quay.io
       repository: thanos/thanos
-      tag: v0.34.1
+      tag: v0.37.2
       sha: ""
 
     ## Set a Label Selector to filter watched prometheus and prometheusAgent
@@ -3235,6 +3411,42 @@ kube-prometheus-stack:
         #   hosts:
         #     - prometheus.example.com
 
+    # -- BETA: Configure the gateway routes for the chart here.
+    # More routes can be added by adding a dictionary key like the 'main' route.
+    # Be aware that this is an early beta of this feature,
+    # kube-prometheus-stack does not guarantee this works and is subject to change.
+    # Being BETA this can/will change in the future without notice, do not use unless you want to take that risk
+    # [[ref]](https://gateway-api.sigs.k8s.io/references/spec/#gateway.networking.k8s.io%2fv1alpha2)
+    route:
+      main:
+        # -- Enables or disables the route
+        enabled: false
+
+        # -- Set the route apiVersion, e.g. gateway.networking.k8s.io/v1 or gateway.networking.k8s.io/v1alpha2
+        apiVersion: gateway.networking.k8s.io/v1
+        # -- Set the route kind
+        # Valid options are GRPCRoute, HTTPRoute, TCPRoute, TLSRoute, UDPRoute
+        kind: HTTPRoute
+
+        annotations: {}
+        labels: {}
+
+        hostnames: []
+        # - my-filter.example.com
+        parentRefs: []
+        # - name: acme-gw
+
+        matches:
+        - path:
+            type: PathPrefix
+            value: /
+
+        ## Filters define the filters that are applied to requests that match this rule.
+        filters: []
+
+        ## Additional custom rules that can be added to the route
+        additionalRules: []
+
     ## Configuration for creating an Ingress that will map to each Prometheus replica service
     ## prometheus.servicePerReplica must be enabled
     ##
@@ -3355,8 +3567,24 @@ kube-prometheus-stack:
     ## ref: https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api.md#prometheusspec
     ##
     prometheusSpec:
+      ## Statefulset's persistent volume claim retention policy
+      ## whenDeleted and whenScaled determine whether
+      ## statefulset's PVCs are deleted (true) or retained (false)
+      ## on scaling down and deleting statefulset, respectively.
+      ## Requires Kubernetes version 1.27.0+.
+      ## Ref: https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#persistentvolumeclaim-retention
+      persistentVolumeClaimRetentionPolicy: {}
+      #  whenDeleted: Retain
+      #  whenScaled: Retain
+
       ## If true, pass --storage.tsdb.max-block-duration=2h to prometheus. This is already done if using Thanos
       ##
+      ## AutomountServiceAccountToken indicates whether a service account token should be automatically mounted in the pod,
+      ## If the field isn’t set, the operator mounts the service account token by default.
+      ## Warning: be aware that by default, Prometheus requires the service account token for Kubernetes service discovery,
+      ## It is possible to use strategic merge patch to project the service account token into the ‘prometheus’ container.
+      automountServiceAccountToken: true
+
       disableCompaction: false
       ## APIServerConfig
       ## ref: https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api.md#apiserverconfig
@@ -3376,6 +3604,16 @@ kube-prometheus-stack:
       ## Number of seconds to wait for target to respond before erroring
       ##
       scrapeTimeout: ""
+
+      ## List of scrape classes to expose to scraping objects such as
+      ## PodMonitors, ServiceMonitors, Probes and ScrapeConfigs.
+      ##
+      scrapeClasses: []
+      # - name: istio-mtls
+      #   default: false
+      #   tlsConfig:
+      #     caFile: /etc/prometheus/secrets/istio.default/root-cert.pem
+      #     certFile: /etc/prometheus/secrets/istio.default/cert-chain.pem
 
       ## Interval between consecutive evaluations.
       ##
@@ -3417,7 +3655,7 @@ kube-prometheus-stack:
       image:
         registry: quay.io
         repository: prometheus/prometheus
-        tag: v2.51.2
+        tag: v3.0.1
         sha: ""
 
       ## Tolerations for use with node taints
@@ -3608,6 +3846,9 @@ kube-prometheus-stack:
       ## prometheus resource to be created with selectors based on values in the helm deployment,
       ## which will also match the scrapeConfigs created
       ##
+      ## If null and scrapeConfigSelector is also null, exclude field from the prometheusSpec
+      ## (keeping downward compatibility with older versions of CRD)
+      ##
       scrapeConfigSelectorNilUsesHelmValues: true
 
       ## scrapeConfigs to be selected for target discovery.
@@ -3620,6 +3861,7 @@ kube-prometheus-stack:
       #     prometheus: somelabel
 
       ## If nil, select own namespace. Namespaces to be selected for scrapeConfig discovery.
+      ## If null, exclude the field from the prometheusSpec (keeping downward compatibility with older versions of CRD)
       scrapeConfigNamespaceSelector: {}
       ## Example which selects scrapeConfig in namespaces with label "prometheus" set to "somelabel"
       # scrapeConfigNamespaceSelector:
@@ -3686,7 +3928,7 @@ kube-prometheus-stack:
       ## The default value "soft" means that the scheduler should *prefer* to not schedule two replica pods onto the same node but no guarantee is provided.
       ## The value "hard" means that the scheduler is *required* to not schedule two replica pods onto the same node.
       ## The value "" will disable pod anti-affinity so that no anti-affinity rules will be configured.
-      podAntiAffinity: ""
+      podAntiAffinity: "soft"
 
       ## If anti-affinity is enabled sets the topologyKey to use for anti-affinity.
       ## This can be changed to, for example, failure-domain.beta.kubernetes.io/zone
@@ -4044,6 +4286,10 @@ kube-prometheus-stack:
       ## See https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api.md#prometheustracingconfig
       tracingConfig: {}
 
+      ## Defines the service discovery role used to discover targets from ServiceMonitor objects and Alertmanager endpoints.
+      ## If set, the value should be either “Endpoints” or “EndpointSlice”. If unset, the operator assumes the “Endpoints” role.
+      serviceDiscoveryRole: ""
+
       ## Additional configuration which is not covered by the properties above. (passed through tpl)
       additionalConfig: {}
 
@@ -4055,7 +4301,7 @@ kube-prometheus-stack:
       ## Defines the maximum time that the `prometheus` container's startup probe
       ## will wait before being considered failed. The startup probe will return
       ## success after the WAL replay is complete. If set, the value should be
-      ## greater than 60 (seconds). Otherwise it will be equal to 600 seconds (15
+      ## greater than 60 (seconds). Otherwise it will be equal to 900 seconds (15
       ## minutes).
       maximumStartupDurationSeconds: 0
 
@@ -4091,6 +4337,18 @@ kube-prometheus-stack:
       ## Label selector for services to which this ServiceMonitor applies
       ##
       # selector: {}
+        ## Example which selects all services to be monitored
+        ## with label "monitoredby" with values any of "example-service-1" or "example-service-2"
+        # matchExpressions:
+        #   - key: "monitoredby"
+        #     operator: In
+        #     values:
+        #       - example-service-1
+        #       - example-service-2
+
+        ## label selector for services
+        ##
+        # matchLabels: {}
 
       ## Namespaces from which services are selected
       ##
@@ -4191,6 +4449,18 @@ kube-prometheus-stack:
       ## Label selector for pods to which this PodMonitor applies
       ##
       # selector: {}
+        ## Example which selects all Pods to be monitored
+        ## with label "monitoredby" with values any of "example-pod-1" or "example-pod-2"
+        # matchExpressions:
+        #   - key: "monitoredby"
+        #     operator: In
+        #     values:
+        #       - example-pod-1
+        #       - example-pod-2
+
+        ## label selector for pods
+        ##
+        # matchLabels: {}
 
       ## PodTargetLabels transfers labels on the Kubernetes Pod onto the target.
       ##
@@ -4277,6 +4547,42 @@ kube-prometheus-stack:
       # - secretName: thanosruler-general-tls
       #   hosts:
       #   - thanosruler.example.com
+
+    # -- BETA: Configure the gateway routes for the chart here.
+    # More routes can be added by adding a dictionary key like the 'main' route.
+    # Be aware that this is an early beta of this feature,
+    # kube-prometheus-stack does not guarantee this works and is subject to change.
+    # Being BETA this can/will change in the future without notice, do not use unless you want to take that risk
+    # [[ref]](https://gateway-api.sigs.k8s.io/references/spec/#gateway.networking.k8s.io%2fv1alpha2)
+    route:
+      main:
+        # -- Enables or disables the route
+        enabled: false
+
+        # -- Set the route apiVersion, e.g. gateway.networking.k8s.io/v1 or gateway.networking.k8s.io/v1alpha2
+        apiVersion: gateway.networking.k8s.io/v1
+        # -- Set the route kind
+        # Valid options are GRPCRoute, HTTPRoute, TCPRoute, TLSRoute, UDPRoute
+        kind: HTTPRoute
+
+        annotations: {}
+        labels: {}
+
+        hostnames: []
+        # - my-filter.example.com
+        parentRefs: []
+        # - name: acme-gw
+
+        matches:
+          - path:
+              type: PathPrefix
+              value: /
+
+        ## Filters define the filters that are applied to requests that match this rule.
+        filters: []
+
+        ## Additional custom rules that can be added to the route
+        additionalRules: []
 
     ## Configuration for ThanosRuler service
     ##
@@ -4405,7 +4711,7 @@ kube-prometheus-stack:
       image:
         registry: quay.io
         repository: thanos/thanos
-        tag: v0.34.1
+        tag: v0.37.2
         sha: ""
 
       ## Namespaces to be selected for PrometheusRules discovery.
@@ -4480,7 +4786,7 @@ kube-prometheus-stack:
         existingSecret: {}
           # name: ""
           # key: ""
-        # will render render alertmanagersConfig secret data and configure it to be used by Thanos Ruler custom resource, ignored when alertmanagersConfig.existingSecret is set
+        # will render alertmanagersConfig secret data and configure it to be used by Thanos Ruler custom resource, ignored when alertmanagersConfig.existingSecret is set
         # https://thanos.io/tip/components/rule.md/#alertmanager
         secret: {}
           # alertmanagers:
@@ -4592,7 +4898,7 @@ kube-prometheus-stack:
       ## The value "hard" means that the scheduler is *required* to not schedule two replica pods onto the same node.
       ## The value "" will disable pod anti-affinity so that no anti-affinity rules will be configured.
       ##
-      podAntiAffinity: ""
+      podAntiAffinity: "soft"
 
       ## If anti-affinity is enabled sets the topologyKey to use for anti-affinity.
       ## This can be changed to, for example, failure-domain.beta.kubernetes.io/zone
@@ -4672,6 +4978,10 @@ kube-prometheus-stack:
       ##
       portName: "web"
 
+      ## WebTLSConfig defines the TLS parameters for HTTPS
+      ## ref: https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api.md#thanosrulerwebspec
+      web: {}
+
       ## Additional configuration which is not covered by the properties above. (passed through tpl)
       additionalConfig: {}
 
@@ -4703,6 +5013,7 @@ kube-prometheus-stack:
     #     name: prometheus-extra
     #   data:
     #     extra-data: "value"
+
 
 
 # Thanos


### PR DESCRIPTION
Updates:
- Upgraded kube-prometheus-stack chart to version 67.5.0
- Upgraded nopo11y-stack chart version to 2.0.0